### PR TITLE
Support APK Signature Scheme v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This plugin also depends on Android's  [`apksig`](https://android.googlesource.c
 library to sign APKs programmatically. `apksig` backs the [`apksigner`](https://developer.android.com/studio/command-line/apksigner.html)
 utility in the Android SDK Developer Tools package.  Using `apksig` ensures the signed APKs
 this plugin produces comply with the newer
-[APK Signature Scheme v2](https://source.android.com/security/apksigning/v2.html).
+[APK Signature Scheme v2](https://source.android.com/security/apksigning/v2.html) and [APK Signature Scheme v3](https://source.android.com/security/apksigning/v3).
 Thanks to Google/Android for making that library available as a
 [Maven dependency](https://bintray.com/android/android-tools/com.android.tools.build.apksig).
 

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,10 @@
       <id>jcenter</id>
       <url>http://jcenter.bintray.com/</url>
     </repository>
+    <repository>
+      <id>maven.google.com</id>
+      <url>https://maven.google.com</url>
+    </repository>
   </repositories>
 
   <pluginRepositories>
@@ -86,7 +90,7 @@
     <dependency>
       <groupId>com.android.tools.build</groupId>
       <artifactId>apksig</artifactId>
-      <version>2.3.0</version>
+      <version>7.0.3</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/main/java/org/jenkinsci/plugins/androidsigning/SignApksBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/androidsigning/SignApksBuilder.java
@@ -503,7 +503,8 @@ public class SignApksBuilder extends Builder implements SimpleBuildStep {
                 .setOtherSignersSignaturesPreserved(false)
                 // TODO: add to jenkins descriptor
                 .setV1SigningEnabled(true)
-                .setV2SigningEnabled(true);
+                .setV2SigningEnabled(true)
+                .setV3SigningEnabled(true);
 
             ApkSigner signer = signerBuilder.build();
             try {

--- a/src/test/java/org/jenkinsci/plugins/androidsigning/ApkArtifactIsSignedMatcher.java
+++ b/src/test/java/org/jenkinsci/plugins/androidsigning/ApkArtifactIsSignedMatcher.java
@@ -47,6 +47,9 @@ class ApkArtifactIsSignedMatcher extends BaseMatcher<BuildArtifact> {
             if (!result.isVerified) {
                 descText.append(" not verified;");
             }
+            if (!result.isVerifiedV3Scheme) {
+                descText.append(" not verified v3;");
+            }
             if (!result.isVerifiedV2Scheme) {
                 descText.append(" not verified v2;");
             }

--- a/src/test/java/org/jenkinsci/plugins/androidsigning/VerifyApkCallable.java
+++ b/src/test/java/org/jenkinsci/plugins/androidsigning/VerifyApkCallable.java
@@ -28,6 +28,7 @@ class VerifyApkCallable extends MasterToSlaveFileCallable<VerifyApkCallable.Veri
         boolean isVerified;
         boolean isVerifiedV1Scheme;
         boolean isVerifiedV2Scheme;
+        boolean isVerifiedV3Scheme;
         boolean containsErrors;
         X509Certificate[] certs;
         String[] warnings = new String[0];
@@ -37,6 +38,7 @@ class VerifyApkCallable extends MasterToSlaveFileCallable<VerifyApkCallable.Veri
             this.isVerified = result.isVerified();
             this.isVerifiedV1Scheme = result.isVerifiedUsingV1Scheme();
             this.isVerifiedV2Scheme = result.isVerifiedUsingV2Scheme();
+            this.isVerifiedV3Scheme = result.isVerifiedUsingV3Scheme();
             this.certs = result.getSignerCertificates().toArray(new X509Certificate[0]);
             this.containsErrors = result.containsErrors();
             List<String> messages = new ArrayList<>();


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- Add support for signing APKs with APK Signature Scheme v3. Android 9 and above support v3 scheme to be able to utilize key rotation of the signing key.
- Add google maven as a repository to be able to upgrade `apksig` lib to latest stable version (7.0.3)

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
