### PR TITLE
chore: Add Google Maven repository to resolve apksig 8.10.1 dependency

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-buildPlugin(useContainerAgent: true, configurations: [
+buildPlugin(useArtifactCachingProxy: false, failFast: false, useContainerAgent: true, configurations: [
   [platform: 'linux', jdk: 21],
   [platform: 'windows', jdk: 17],
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
     <dependency>
       <groupId>com.android.tools.build</groupId>
       <artifactId>apksig</artifactId>
-      <version>8.10.1</version>
+      <version>7.4.0</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -57,10 +57,6 @@
     <!-- Google repository provides the library for signing APKs and for checking that APK signatures verify on Android -->
     <!-- com.android.tools.build:apksig -->
     <repository>
-      <id>maven.google.com</id>
-      <url>https://maven.google.com</url>
-    </repository>
-    <repository>
       <id>google</id>
       <name>Google Maven Repository</name>
       <url>https://dl.google.com/dl/android/maven2/</url>

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,11 @@
       <id>maven.google.com</id>
       <url>https://maven.google.com</url>
     </repository>
+    <repository>
+      <id>google</id>
+      <name>Google Maven Repository</name>
+      <url>https://dl.google.com/dl/android/maven2/</url>
+    </repository>
   </repositories>
 
   <pluginRepositories>
@@ -82,7 +87,7 @@
     <dependency>
       <groupId>com.android.tools.build</groupId>
       <artifactId>apksig</artifactId>
-      <version>7.4.0</version>
+      <version>8.10.1</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>


### PR DESCRIPTION
### Overview

This Pull Request is a follow-up to #10, addressing the need to resolve the `com.android.tools.build:apksig` dependency, specifically version 8.10.1, which requires access to Google's Maven repository.

### Implementation Details

- **pom.xml Update**
  - The `pom.xml` file has been updated to include Google's official Maven repository in the `<repositories>` section:

    ```xml
    <repository>
        <id>google</id>
        <name>Google</name>
        <url>https://dl.google.com/dl/android/maven2/</url>
    </repository>
    ```

  - The `com.android.tools.build:apksig` dependency has been restored to version 8.10.1. This ensures that the build process can resolve and download the required version directly from Google's repository.

- **Build Environment Note**
  - Although this update builds successfully both locally and in cloud environments, it encounters issues on the Jenkins infrastructure. The artifact caching proxy appears unable to retrieve the dependency from the newly-added Maven repository.

### Conclusion

By integrating the Google Maven repository into the `pom.xml`, this PR resolves the dependency issue for the `apksig` library, ensuring smoother builds in supported environments. Further investigation and adjustments might be necessary to address the Jenkins infrastructure discrepancies related to artifact retrieval.