### PR TITLE
Fix spotbugs RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/androidsigning/MultiEntryToSingleEntryBuilderMigration.java
+++ b/src/main/java/org/jenkinsci/plugins/androidsigning/MultiEntryToSingleEntryBuilderMigration.java
@@ -24,10 +24,6 @@ public class MultiEntryToSingleEntryBuilderMigration extends ItemListener {
     @Override
     public void onLoaded() {
         Jenkins jenkins = Jenkins.get();
-        if (jenkins == null) {
-            log.warning("jenkins instance is null; cannot migrate old job data");
-            return;
-        }
         List<Project> jobs = jenkins.getAllItems(Project.class);
         for (Project<?,?> job : jobs) {
             migrateBuildersOfJob(job);


### PR DESCRIPTION
Redundant nullcheck of jenkins, which is known to be non-null in org.jenkinsci.plugins.androidsigning.MultiEntryToSingleEntryBuilderMigration.onLoaded()

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
