### PR TITLE
Remove depracted method JUnit Assert.assertThat

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/androidsigning/SignApksBuilderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/androidsigning/SignApksBuilderTest.java
@@ -78,7 +78,7 @@ import static org.jenkinsci.plugins.androidsigning.ApkArtifactIsSignedMatcher.is
 import static org.jenkinsci.plugins.androidsigning.TestKeyStore.KEY_ALIAS;
 import static org.jenkinsci.plugins.androidsigning.TestKeyStore.KEY_STORE_ID;
 import static org.jenkinsci.plugins.androidsigning.TestKeyStore.KEY_STORE_RESOURCE;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 

--- a/src/test/java/org/jenkinsci/plugins/androidsigning/SignApksStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/androidsigning/SignApksStepTest.java
@@ -24,7 +24,7 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.CoreMatchers.startsWith;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
 

--- a/src/test/java/org/jenkinsci/plugins/androidsigning/ZipalignToolTest.java
+++ b/src/test/java/org/jenkinsci/plugins/androidsigning/ZipalignToolTest.java
@@ -19,7 +19,7 @@ import hudson.Util;
 import hudson.util.ArgumentListBuilder;
 
 import static org.hamcrest.CoreMatchers.startsWith;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 
 public class ZipalignToolTest {

--- a/src/test/java/org/jenkinsci/plugins/androidsigning/compatibility/SignApksBuilderCompatibility_2_0_8_Test.java
+++ b/src/test/java/org/jenkinsci/plugins/androidsigning/compatibility/SignApksBuilderCompatibility_2_0_8_Test.java
@@ -17,7 +17,7 @@ import hudson.util.DescribableList;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 
 public class SignApksBuilderCompatibility_2_0_8_Test {

--- a/src/test/java/org/jenkinsci/plugins/androidsigning/compatibility/SignApksBuilderCompatibility_2_1_0_Test.java
+++ b/src/test/java/org/jenkinsci/plugins/androidsigning/compatibility/SignApksBuilderCompatibility_2_1_0_Test.java
@@ -18,7 +18,7 @@ import hudson.util.DescribableList;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 
 public class SignApksBuilderCompatibility_2_1_0_Test {


### PR DESCRIPTION
The JUnit Assert.assertThat method is deprecated. Its sole purpose is to forward the call to the MatcherAssert.assertThat (opens new window)method defined in Hamcrest 1.3. Therefore, it is recommended to directly use the equivalent assertion defined in the third party Hamcrest library. This rule finds the deprecated usages of Assert.assertThat and automatically replaces them with MatcherAssert.assertThat. Since JUnit 5 contains no equivalent assertion for assertThat, this rule eliminates an obstacle for migration to JUnit 5.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
