### PR TITLE
Use HTTPS protocol instead of Git in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ You can include a _Sign Android APKs_ build step in the `steps` context of a Job
 ```
 freeStyleJob('myApp.seed') {
     scm {
-        git 'git://github.com/mygithub/myApp.git', 'master', {
+        git 'https://github.com/mygithub/myApp.git', 'master', {
             extensions {
                 relativeTragetDirectory 'myApp'
             }


### PR DESCRIPTION
## Use HTTPS protocol instead of Git protocol in documentation

GitHub no longer supports the git protocol.

More information is available in their [blog post](https://github.blog/security/application-security/improving-git-protocol-security-github/)

### Testing done

None.  No issue expected, since it is based on [one](https://www.jenkins.io/doc/developer/tutorial-improve/update-scm-url/) of the ["Improve a plugin" tutorials](https://www.jenkins.io/doc/developer/tutorial-improve/).

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
